### PR TITLE
Add RBAC handling with role-aware UI

### DIFF
--- a/app/src/main/java/com/sukuna/animestudio/di/RoleModule.kt
+++ b/app/src/main/java/com/sukuna/animestudio/di/RoleModule.kt
@@ -1,0 +1,16 @@
+package com.sukuna.animestudio.di
+
+import com.sukuna.animestudio.domain.RoleManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RoleModule {
+    @Provides
+    @Singleton
+    fun provideRoleManager(): RoleManager = RoleManager()
+}

--- a/app/src/main/java/com/sukuna/animestudio/domain/RoleManager.kt
+++ b/app/src/main/java/com/sukuna/animestudio/domain/RoleManager.kt
@@ -35,4 +35,8 @@ class RoleManager @Inject constructor() {
     fun isRegularUser(user: User?): Boolean {
         return user?.role == UserRole.USER
     }
-} 
+
+    fun isGuest(user: User?): Boolean {
+        return user?.role == UserRole.GUEST || user == null
+    }
+}

--- a/app/src/main/java/com/sukuna/animestudio/domain/model/UserRole.kt
+++ b/app/src/main/java/com/sukuna/animestudio/domain/model/UserRole.kt
@@ -1,7 +1,12 @@
 package com.sukuna.animestudio.domain.model
 
 enum class UserRole {
-    USER,           // Regular user with basic permissions
-    MODERATOR,      // Can moderate content and users
-    ADMIN           // Full system access
-} 
+    /** User that isn't authenticated */
+    GUEST,
+    /** Regular user with basic permissions */
+    USER,
+    /** Can moderate content and users */
+    MODERATOR,
+    /** Full system access */
+    ADMIN
+}

--- a/app/src/main/java/com/sukuna/animestudio/navigation/NavGraph.kt
+++ b/app/src/main/java/com/sukuna/animestudio/navigation/NavGraph.kt
@@ -4,9 +4,11 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.compose.runtime.remember
 import com.sukuna.animestudio.presentation.auth.AuthScreen
 import com.sukuna.animestudio.presentation.home.HomeScreen
 import com.sukuna.animestudio.presentation.profile.ProfileScreen
+import com.sukuna.animestudio.domain.RoleManager
 
 sealed class Screen(val route: String) {
     object Auth : Screen("auth")
@@ -34,10 +36,12 @@ fun NavGraph(
         }
         
         composable(Screen.Home.route) {
+            val roleManager = remember { RoleManager() }
             HomeScreen(
                 onNavigateToProfile = {
                     navController.navigate(Screen.Profile.route)
-                }
+                },
+                roleManager = roleManager
             )
         }
 

--- a/app/src/main/java/com/sukuna/animestudio/presentation/auth/AuthScreen.kt
+++ b/app/src/main/java/com/sukuna/animestudio/presentation/auth/AuthScreen.kt
@@ -305,6 +305,20 @@ fun AuthScreen(
                         }
                     }
 
+                    // Option to skip authentication and continue as a guest
+                    TextButton(
+                        onClick = viewModel::continueAsGuest,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(
+                            text = "Continue as Guest",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.tertiary,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+
                 }
             }
         }

--- a/app/src/main/java/com/sukuna/animestudio/presentation/auth/AuthViewModel.kt
+++ b/app/src/main/java/com/sukuna/animestudio/presentation/auth/AuthViewModel.kt
@@ -107,6 +107,15 @@ class AuthViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Allow the user to bypass authentication and use the app as a guest.
+     * This simply marks the UI state as authenticated so navigation proceeds
+     * to the home screen where a null user maps to the GUEST role.
+     */
+    fun continueAsGuest() {
+        _uiState.update { it.copy(isAuthenticated = true) }
+    }
+
     fun clearError() {
         _uiState.update { it.copy(error = null) }
     }

--- a/app/src/main/java/com/sukuna/animestudio/presentation/home/HomeScreen.kt
+++ b/app/src/main/java/com/sukuna/animestudio/presentation/home/HomeScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -45,14 +46,19 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.sukuna.animestudio.domain.RoleManager
 import com.sukuna.animestudio.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
-    onNavigateToProfile: () -> Unit
+    onNavigateToProfile: () -> Unit,
+    viewModel: HomeViewModel = hiltViewModel(),
+    roleManager: RoleManager
 ) {
     var searchQuery by remember { mutableStateOf("") }
+    val uiState by viewModel.uiState.collectAsState()
 
     Scaffold(
         topBar = {
@@ -181,6 +187,26 @@ fun HomeScreen(
                         ContinueWatchingCard(anime = anime)
                     }
                 }
+
+                if (uiState.canEditAnime(roleManager) || uiState.canManageUsers(roleManager)) {
+                    Spacer(modifier = Modifier.height(24.dp))
+                    Text(
+                        text = "Admin Tools",
+                        style = MaterialTheme.typography.titleLarge,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                    Column(
+                        modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        if (uiState.canEditAnime(roleManager)) {
+                            AdminActionButton(label = "Add Anime")
+                        }
+                        if (uiState.canManageUsers(roleManager)) {
+                            AdminActionButton(label = "Manage Users")
+                        }
+                    }
+                }
             }
         }
     }
@@ -261,10 +287,24 @@ private fun ContinueWatchingCard(anime: String) {
                 Text(
                     text = "Episode 12 • 24:00",
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun AdminActionButton(label: String) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primary)
+    ) {
+        Text(
+            text = label,
+            modifier = Modifier.padding(16.dp),
+            color = MaterialTheme.colorScheme.onPrimary,
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center
+        )
     }
 }
 
@@ -274,4 +314,4 @@ private val sampleAnimeList = listOf(
     "Attack on Titan",
     "My Hero Academia",
     "Black Clover"
-) 
+)

--- a/app/src/main/java/com/sukuna/animestudio/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/sukuna/animestudio/presentation/home/HomeViewModel.kt
@@ -1,0 +1,60 @@
+package com.sukuna.animestudio.presentation.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sukuna.animestudio.data.repository.AuthRepository
+import com.sukuna.animestudio.data.repository.DbRepository
+import com.sukuna.animestudio.domain.RoleManager
+import com.sukuna.animestudio.domain.model.User
+import com.sukuna.animestudio.domain.model.UserRole
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class HomeViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
+    private val dbRepository: DbRepository,
+    private val roleManager: RoleManager
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(HomeUiState())
+    val uiState: StateFlow<HomeUiState> = _uiState.stateIn(
+        scope = viewModelScope,
+        started = kotlinx.coroutines.flow.SharingStarted.WhileSubscribed(5000),
+        initialValue = HomeUiState()
+    )
+
+    init {
+        loadUser()
+    }
+
+    private fun loadUser() {
+        viewModelScope.launch {
+            val currentUser = authRepository.currentUser
+            val userData = if (currentUser != null) {
+                dbRepository.getUserById(currentUser.uid)
+            } else null
+            _uiState.update { state ->
+                state.copy(user = userData)
+            }
+        }
+    }
+}
+
+data class HomeUiState(
+    val user: User? = null
+) {
+    val role: UserRole
+        get() = user?.role ?: UserRole.GUEST
+
+    fun canEditAnime(roleManager: RoleManager) =
+        roleManager.canEditAnime(user)
+
+    fun canManageUsers(roleManager: RoleManager) =
+        roleManager.canManageUsers(user)
+}

--- a/app/src/main/java/com/sukuna/animestudio/presentation/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/sukuna/animestudio/presentation/profile/ProfileScreen.kt
@@ -192,7 +192,7 @@ fun ProfileScreen(
                     )
                 ) {
                     Text(
-                        text = uiState.user?.role?.name ?: "USER",
+                        text = uiState.user?.role?.name ?: "GUEST",
                         modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
                         style = MaterialTheme.typography.labelMedium,
                         color = MaterialTheme.colorScheme.onPrimary

--- a/app/src/main/java/com/sukuna/animestudio/presentation/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/sukuna/animestudio/presentation/profile/ProfileViewModel.kt
@@ -190,8 +190,8 @@ class ProfileViewModel @Inject constructor(
 }
 
 data class ProfileUiState(
-    val user: User? = User(),
+    val user: User? = null,
     val isLoading: Boolean = false,
     val error: String? = null,
     val isSignedOut: Boolean = false
-) 
+)


### PR DESCRIPTION
## Summary
- extend `UserRole` with `GUEST`
- provide `RoleManager` singleton via new `RoleModule`
- create `HomeViewModel` to expose user role and role checks
- update `HomeScreen` to show admin tools when permissions allow
- display `GUEST` fallback in `ProfileScreen`
- update navigation to supply a `RoleManager`
- minor fixes to layout closing braces
- allow guest authentication option

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684ff4753e4083279c7f96e5b7ac08e4